### PR TITLE
feat: Add settings input validation

### DIFF
--- a/app/src/main/kotlin/com/camerasecuritysystem/client/ConnectDialog.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/ConnectDialog.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
-import android.view.View
-import android.widget.EditText
+import android.widget.Button
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.widget.doOnTextChanged
+import com.camerasecuritysystem.client.databinding.ConnectDialogLayoutBinding
 import java.lang.Exception
+import java.lang.NumberFormatException
 
 class ConnectDialog : AppCompatDialogFragment() {
 
@@ -19,15 +21,34 @@ class ConnectDialog : AppCompatDialogFragment() {
 
     private lateinit var sharedPreferences: SharedPreferences
 
+    private lateinit var binding: ConnectDialogLayoutBinding
+
+    private var cameraValid: Boolean    = false
+    private var portValid:   Boolean    = false
+    private var ipAddrValid: Boolean    = false
+    private var passWdValid: Boolean    = false
+
+    private var okButton: Button? = null
+
+    private lateinit var cameraidStr:  String
+    private lateinit var portStr:      String
+    private lateinit var ipaddressStr: String
+    private lateinit var passwordStr:  String
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val inflater = requireActivity().layoutInflater
-        val view: View = inflater.inflate(R.layout.connect_dialog_layout, null)
+        binding = ConnectDialogLayoutBinding.inflate(inflater)
+
+        this.cameraidStr    = resources.getString(R.string.camera_id)
+        this.portStr        = resources.getString(R.string.port)
+        this.ipaddressStr   = resources.getString(R.string.ip_address)
+        this.passwordStr    = resources.getString(R.string.password)
 
         //Get the id of the input fields
-        val editTextUsername = view.findViewById<EditText>(R.id.edit_camera_id)
-        val editTextPort = view.findViewById<EditText>(R.id.edit_port)
-        val editTextIPAddress = view.findViewById<EditText>(R.id.edit_ip_address)
-        val editTextPassword = view.findViewById<EditText>(R.id.edit_password)
+        val editTextCameraId  = binding.editCameraId
+        val editTextPort      = binding.editPort
+        val editTextIPAddress = binding.editIpAddress
+        val editTextPassword  = binding.editPassword
 
         //Get access to all shared preferences
         sharedPreferences = requireContext().getSharedPreferences(
@@ -35,8 +56,8 @@ class ConnectDialog : AppCompatDialogFragment() {
             Context.MODE_PRIVATE)
 
         //Assign the preferences to variables
-        val cameraId = sharedPreferences.getString("camera_id", null)
-        val port = sharedPreferences.getString("port", null)
+        val cameraId  = sharedPreferences.getString("camera_id", null)
+        val port      = sharedPreferences.getString("port", null)
         val ipAddress = sharedPreferences.getString("ip_address", null)
 
         val encPwd = sharedPreferences.getString("encPwd", null)
@@ -53,46 +74,190 @@ class ConnectDialog : AppCompatDialogFragment() {
                 )
 
                 //Set the password text in the input field
-                editTextPassword.setText(pwdText)
+                binding.editPassword.setText(pwdText)
+                passWdValid = true
 
             } catch (e: Exception) {
                 Log.e("EXCEPTION", "error: ", e)
             }
         }
 
-        //Set the camera text in the input field
-        if (cameraId != null) {
-            editTextUsername.setText(cameraId)
-        }
-
-        //Set the port text in the input field
-        if (port != null) {
-            editTextPort.setText(port)
-        }
-
-        //Set the IP text in the input field
-        if (ipAddress != null) {
-            editTextIPAddress.setText(ipAddress)
-        }
-
-        //Return the dialog window
-        return AlertDialog.Builder(requireActivity())
-            .setView(view)
+        //Create the dialog window
+        val dialog = AlertDialog.Builder(requireActivity())
+            .setView(binding.root)
             .setTitle("Login")
             .setNegativeButton("Cancel") { _, _ -> }
             .setPositiveButton("Ok") { _, _ ->
 
-                //TODO Hier moet de inputvalidatie komen. Daarnaast moet er een error getoond worden
-                // https://stackoverflow.com/questions/30953449/design-android-edittext-to-show-error-message-as-described-by-google
-                val cameraIdText = editTextUsername.text.toString()
+                // At this point, the input values can be retrieved from the dialog
+                // since the OK button is disabled until they are valid.
+                val cameraIdText = editTextCameraId.text.toString()
                 val portText = editTextPort.text.toString()
-                val ipAddresstext = editTextIPAddress.text.toString()
+                val ipAddressText = editTextIPAddress.text.toString()
                 val passwordText = editTextPassword.text.toString()
 
                 //Pass the new input values to store them in the shared preferences
-                listener!!.applyTexts(cameraIdText, portText, ipAddresstext, passwordText)
+                listener!!.applyTexts(cameraIdText, portText, ipAddressText, passwordText)
             }
             .create()
+
+        dialog.setOnShowListener {
+            this.okButton = (it as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE)
+
+            //Set the initial values for the input fields and update the OK button
+            if (cameraId != null) {
+                binding.editCameraId.setText(cameraId)
+                cameraValid = true
+            } else {
+                binding.inputLayoutCameraID.error = String.format(resources.getString(R.string.err_not_empty), cameraidStr)
+                setOkButton(okButton)
+            }
+            //Set the port text in the input field
+            if (port != null) {
+                binding.editPort.setText(port)
+                portValid = true
+            } else {
+                binding.inputLayoutPort.error = String.format(resources.getString(R.string.err_not_empty), portStr)
+                setOkButton(okButton)
+            }
+            //Set the IP text in the input field
+            if (ipAddress != null) {
+                binding.editIpAddress.setText(ipAddress)
+                ipAddrValid = true
+            } else {
+                binding.inputLayoutIpAddress.error = String.format(resources.getString(R.string.err_not_empty), ipaddressStr)
+                setOkButton(okButton)
+            }
+            //Check if the ivByte and encrypted password exist
+            if (ivByte != null && encPwd != null) {
+
+                //Decrypt the IV byte and the password
+                try {
+                    val pwdText = keyStore.decryptData(
+                        ivByte.toByteArray(Charsets.ISO_8859_1),
+                        encPwd.toByteArray(Charsets.ISO_8859_1)
+                    )
+
+                    //Set the password text in the input field
+                    editTextPassword.setText(pwdText)
+                    passWdValid = true
+
+                } catch (e: Exception) {
+                    Log.e("EXCEPTION", "error: ", e)
+                    setOkButton(okButton)
+                }
+            } else {
+                binding.inputLayoutPassword.error = String.format(resources.getString(R.string.err_not_empty), passwordStr)
+                setOkButton(okButton)
+            }
+
+            // Add text change handlers used for input validation
+            binding.editCameraId.doOnTextChanged { text, _, _, _ ->
+                cameraValid = validateCameraId(text?.toString())
+                setOkButton(okButton)
+            }
+            binding.editPort.doOnTextChanged { text, _, _, _ ->
+                portValid = validatePort(text?.toString())
+                setOkButton(okButton)
+            }
+            binding.editIpAddress.doOnTextChanged { text, _, _, _ ->
+                ipAddrValid = validateIPAddress(text?.toString())
+                setOkButton(okButton)
+            }
+            binding.editPassword.doOnTextChanged { text, _, _, _ ->
+                passWdValid = validatePassword(text?.toString())
+                setOkButton(okButton)
+            }
+        }
+
+        // Return the dialog window
+        return dialog
+    }
+
+    private fun setOkButton(okButton: Button?) {
+        okButton?.isEnabled = ( cameraValid && portValid && ipAddrValid && passWdValid )
+    }
+
+
+    /* The following validation functions will try to sanitize the user input at least
+     * somewhat, and show an appropriate error. */
+
+    private fun validateCameraId(cameraIdText: String?): Boolean {
+        val camera_til = binding.inputLayoutCameraID
+
+        if (cameraIdText == null || cameraIdText.isEmpty()) {
+            camera_til.error = String.format(resources.getString(R.string.err_not_empty), cameraidStr)
+            return false
+        }
+
+        try {
+            val cameraIdAsInt = cameraIdText.toInt()
+            if (cameraIdAsInt < 1) {
+                camera_til.error = String.format(resources.getString(R.string.err_at_least), cameraidStr, 1)
+                return false
+            }
+        } catch (ex: NumberFormatException) {
+            camera_til.error = String.format(resources.getString(R.string.err_must_be_number), cameraidStr)
+            return false
+        }
+
+        camera_til.error = null
+        return true
+    }
+
+    private fun validatePort(portText: String?): Boolean {
+        val port_til = binding.inputLayoutPort
+
+        if (portText == null || portText.isEmpty()) {
+            port_til.error = String.format(resources.getString(R.string.err_not_empty), portStr)
+            return false
+        }
+
+        try {
+            val portAsInt = portText.toInt()
+            if (portAsInt < 1) {
+                port_til.error = String.format(resources.getString(R.string.err_at_least), portStr, 1)
+                return false
+            }
+            if (portAsInt > 65535) {
+                port_til.error = String.format(resources.getString(R.string.err_at_most), portStr, 65535)
+                return false
+            }
+        } catch (ex: NumberFormatException) {
+            port_til.error = String.format(resources.getString(R.string.err_must_be_number), portStr)
+            return false
+        }
+
+        port_til.error = null
+        return true
+    }
+
+    private fun validateIPAddress(ipAddressText: String?): Boolean {
+        val ipAddress_til = binding.inputLayoutIpAddress
+
+        if (ipAddressText == null || ipAddressText.isEmpty()) {
+            ipAddress_til.error = String.format(resources.getString(R.string.err_not_empty), ipaddressStr)
+            return false
+        }
+
+        // TODO: more thorough validation
+
+        ipAddress_til.error = null
+        return true
+    }
+
+    private fun validatePassword(passwordText: String?): Boolean {
+        val password_til = binding.inputLayoutPassword
+
+        if (passwordText == null || passwordText.isEmpty()) {
+            password_til.error = String.format(resources.getString(R.string.err_not_empty), passwordStr)
+            return false
+        }
+
+        // TODO: more thorough validation
+
+        password_til.error = null
+        return true
     }
 
     /**
@@ -111,6 +276,6 @@ class ConnectDialog : AppCompatDialogFragment() {
     }
 
     interface ConnectDialogListener {
-        fun applyTexts(cameraID: String?, port: String?, ipAddress: String?, password: String?)
+        fun applyTexts(cameraID: String, port: String, ipAddress: String, password: String)
     }
 }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/SettingsActivity.kt
@@ -46,31 +46,23 @@ class SettingsActivity : AppCompatActivity(),
         return false
     }
 
-    override fun applyTexts(cameraID: String?, port: String?, ipAddress: String?, password: String?) {
-        //TODO Input validatie
-        if (password != null) {
-            val pair = keyStore.encryptData(password)
+    override fun applyTexts(cameraID: String, port: String, ipAddress: String, password: String) {
 
-            sharedPreferences.edit().putString("pwdIVByte", pair.first.toString(Charsets.ISO_8859_1))
-                .apply()
-            sharedPreferences.edit().putString("encPwd", pair.second.toString(Charsets.ISO_8859_1))
-                .apply()
-        }
+        // Encrypt the password
+        val pair = keyStore.encryptData(password)
 
-        //TODO Input validatie
-        if (port != null) {
-            sharedPreferences.edit().putString("port", port).apply()
-        }
+        // Store the IV bytes encrypted and the password
+        sharedPreferences.edit()
+            .putString("pwdIVByte", pair.first.toString(Charsets.ISO_8859_1))
+            .apply()
+        sharedPreferences.edit()
+            .putString("encPwd", pair.second.toString(Charsets.ISO_8859_1))
+            .apply()
 
-        //TODO Input validatie
-        if (ipAddress != null) {
-            sharedPreferences.edit().putString("ip_address", ipAddress).apply()
-        }
+        sharedPreferences.edit().putString("port", port).apply()
 
-        //TODO Input validatie
-        if (cameraID != null && cameraID != "") {
-            sharedPreferences.edit().putString("camera_id", cameraID).apply()
-        }
+        sharedPreferences.edit().putString("ip_address", ipAddress).apply()
+
+        sharedPreferences.edit().putString("camera_id", cameraID).apply()
     }
-
 }

--- a/app/src/main/res/layout/connect_dialog_layout.xml
+++ b/app/src/main/res/layout/connect_dialog_layout.xml
@@ -11,19 +11,20 @@
         android:id="@+id/inputLayoutCameraID"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Camera ID"
+        android:hint="@string/camera_id"
         android:scrollbarSize="25dp"
         app:boxBackgroundColor="@color/white"
 
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit_camera_id"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:inputType="text" />
+            android:inputType="number" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -39,7 +40,8 @@
 
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputLayoutCameraID">
+        app:layout_constraintTop_toBottomOf="@+id/inputLayoutCameraID"
+        app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit_port"
@@ -61,30 +63,32 @@
 
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputLayoutPort">
+        app:layout_constraintTop_toBottomOf="@+id/inputLayoutPort"
+        app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit_ip_address"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:inputType="phone" />
+            android:inputType="text" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
 
+        android:id="@+id/inputLayoutPassword"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Password"
+        android:hint="@string/password"
         android:scrollbarSize="25dp"
         app:boxBackgroundColor="@color/white"
 
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/inputLayoutIpAddress"
-        app:passwordToggleEnabled="true">
-
+        app:passwordToggleEnabled="true"
+        app:errorEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit_password"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,11 +13,16 @@
 
     <string name="title_activity_settings">SettingsActivity</string>
 
-
     <string name="capture">Capture</string>
     <string name="camera">Camera</string>
     <string name="stop">stop</string>
     <string name="Idle">Idle</string>
     <color name="txWhite">#FFFFFFFF</color>
 
+    <!-- Validation errors -->
+    <string name="err_not_empty">%1$s cannot be empty!</string>
+    <string name="err_must_be_number">%1$s must be a number!</string>
+    <string name="err_at_least">%1$s must be %2$d at minimum!</string>
+    <string name="err_at_most">%1$s must be %2$d as maximum!</string>
 </resources>
+s


### PR DESCRIPTION
Notable changes:
- The TextInputLayouts now have errors enabled. The password layout
was also missing an ID. The camera and password layouts get a proper
hint. The IP address layout is now a text input instead of phone
number input. The Camera ID input is a number input instead of a text.
- When the alert dialog is first created, the values from the Shared
Preferences are loaded and checked if they are null. If they are, the
appropriate error message will display and the OK button will be
disabled. This button is only enabled if all fields are validated.
- When text in the input fields changes, the new value is checked for
validation. If they are valid, the error is cleared.
- When applying the text from the alert dialog, the values are not
checked anymore, since the OK button can only be pressed when the
values are valid and thus non-null.