### PR TITLE
feat/refac: Reuse client to allow disconnecting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CameraSecuritySystem"
         android:usesCleartextTraffic="true">
+
         <activity
             android:name=".VideoPlayerActivity"
             android:exported="false" />
@@ -30,7 +31,8 @@
         <activity
             android:name=".SettingsActivity"
             android:exported="false"
-            android:label="@string/title_activity_settings" />
+            android:label="@string/title_activity_settings"
+            android:screenOrientation="portrait" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/MainActivity.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/MainActivity.kt
@@ -16,8 +16,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.camerasecuritysystem.client.databinding.ActivityMainBinding
 import com.camerasecuritysystem.client.models.ServerConnection
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
@@ -45,14 +43,12 @@ class MainActivity : AppCompatActivity() {
 
         connectionLiveData = ConnectionLiveData(this)
         connectionLiveData.observe(this, { isNetworkAvailable ->
-            Log.e("NETWORK", "Connected = $isNetworkAvailable")
+            Log.e("NETWORK", "hasInternet = $isNetworkAvailable")
 
+            // TODO: Check for autostart==true
             if (isNetworkAvailable) {
-                GlobalScope.launch {
-                    ServerConnection.getInstance().connectIfPossible(context)
-                }
+                ServerConnection.getInstance().connectIfPossible(context)
             }
-
         })
     }
 

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/ServerLiveData.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/ServerLiveData.kt
@@ -1,0 +1,17 @@
+package com.camerasecuritysystem.client
+
+import androidx.lifecycle.LiveData
+import com.camerasecuritysystem.client.models.ConnectionState
+import com.camerasecuritysystem.client.models.ServerConnection
+
+class ServerLiveData : LiveData<ConnectionState>() {
+
+    private val serverConnection = ServerConnection.getInstance()
+    private val listener = { state: ConnectionState ->
+        postValue(state)
+    }
+
+    override fun onActive() {
+        serverConnection.addStateCallback(listener)
+    }
+}

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/Utils.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/Utils.kt
@@ -1,0 +1,13 @@
+package com.camerasecuritysystem.client
+
+inline fun cassert(value: Boolean) {
+    if (BuildConfig.DEBUG) {
+        assert(value)
+    }
+}
+
+inline fun cassert(value: Boolean, message: String) {
+    if (BuildConfig.DEBUG) {
+        assert(value) { message }
+    }
+}

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/ConnectionState.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/ConnectionState.kt
@@ -1,0 +1,8 @@
+package com.camerasecuritysystem.client.models
+
+enum class ConnectionState {
+    NO_CREDENTIALS,
+    CLOSED,
+    CONNECTING,
+    CONNECTED
+}

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
@@ -178,7 +178,7 @@ class ServerConnection {
         }
     }
 
-    fun isConnected() = webSocketSession != null && state != ConnectionState.CLOSED
+    fun isConnected() = webSocketSession != null && state == ConnectionState.CONNECTED
 
     fun addStateCallback(callback: ((state: ConnectionState) -> Unit)) {
         _listener = callback
@@ -210,16 +210,20 @@ class ServerConnection {
             return
         }
 
+        if (state == ConnectionState.CONNECTING) {
+            Log.e(tag, "Won't connect when connecting!")
+            return
+        }
+
         if (!credentialsEntered(context)) {
             state = ConnectionState.NO_CREDENTIALS
             return
         }
 
+        // If we are here, the user has successfully entered credentials.
         if (state == ConnectionState.NO_CREDENTIALS) {
             _state = ConnectionState.CLOSED // Don't invoke callback
         }
-
-        cassert(webSocketSession == null)
 
         GlobalScope.launch {
             initializeConnection(getCredentials(context))

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -8,34 +8,42 @@
     android:padding="16dp"
     android:weightSum="100">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/connectBox"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:layout_weight="10"
-        android:orientation="horizontal"
-        android:weightSum="10">
+        android:layout_weight="5"
+        android:orientation="horizontal">
 
         <TextView
             android:id="@+id/textViewConnectionSettings"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_weight="8"
             android:gravity="center"
-            android:scrollHorizontally="false"
-            android:text="Tap to edit connection settings"
-            tools:layout_editor_absoluteX="0dp" />
+            android:scrollHorizontally="true"
+
+            android:text="@string/tap_to_edit_connection_settings"
+            android:layout_marginEnd="24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/connectBtn"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_weight="2"
+            android:layout_height="wrap_content"
+
+
             android:backgroundTint="@color/design_default_color_primary"
             android:text="Connect"
-            android:textColor="@color/white" />
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/connectBox"
+            app:layout_constraintStart_toEndOf="@+id/textViewConnectionSettings"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/fragment_length_layout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,6 @@
     <!-- Text for share Intent-->
     <string name="share_text">This video was shared with the CameraSecuritySystem app!</string>
     <string name="title_activity_gallery">Gallery</string>
+
+    <string name="tap_to_edit_connection_settings">Tap to edit connection settings</string>
 </resources>


### PR DESCRIPTION
Notable changes:
- Globalscope.launch has been moved to the ServerConnection class to
simplify its usage.
- Don't call client.close(), otherwise the client will have to be
recreated. Closing the websocketChannel is enough.
- Allow disconnecting when succesfully connected. The button also
reflects the connecting stage. When no credentials are entered, the
button is invisible.
- Two utility functions have been implemented to facilitate debug mode
assertions (only enabled in debug mode). These are used to verify the
websocket (dis)connecting procedure.
- To communicate the state of the connection to activities, a LiveData
implementation is used to allow for callbacks to be executed in the
relevant activity.
- Connect button styling has been fixed for smaller devices.