### PR TITLE
fix: Don't fail release build on example leftovers

### DIFF
--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-        <dimen name="fab_margin">48dp</dimen>
-    </resources>

--- a/app/src/main/res/values-w1240dp/dimens.xml
+++ b/app/src/main/res/values-w1240dp/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-        <dimen name="fab_margin">200dp</dimen>
-    </resources>

--- a/app/src/main/res/values-w600dp/dimens.xml
+++ b/app/src/main/res/values-w600dp/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-        <dimen name="fab_margin">48dp</dimen>
-    </resources>


### PR DESCRIPTION
When building in release mode, the build will fail with a linting
error: MissingDefaultResource. This is caused by there being no
dimens.xml file in the values folder, while there were dimens.xml
files in the values-land, etc. folders. This is a leftover from the
example project, which actually used FloatingActionButton margins.