### PR TITLE
fix: Log receive errors, finally close connection

### DIFF
--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
@@ -110,10 +110,12 @@ class ServerConnection {
                     }
                 } catch (ex: ClosedChannelException) {
                     Log.e("Channel closed", "${ex.message}")
+                } catch (ex: Exception) {
+                    Log.e(tag, "Error occured while receiving: ${ex.message}")
+                } finally {
+                    webSocketSession?.close()
+                    webSocketSession = null
                 }
-
-                webSocketSession?.close()
-                webSocketSession = null
             }
 
             Log.d(tag, "go-away")


### PR DESCRIPTION
Other exceptions than a a ClosedChannelException were never caught,
resulting in never closing and resetting the webSocketSession. This
would trigger the assert at the end of the function.