### PR TITLE
Respond to footage requests from server

### DIFF
--- a/app/src/main/kotlin/com/camerasecuritysystem/client/CSSApplication.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/CSSApplication.kt
@@ -1,0 +1,15 @@
+package com.camerasecuritysystem.client
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.content.Context
+
+@SuppressLint("StaticFieldLeak")
+object CSSApplication : Application() {
+    private lateinit var _context: Context
+    var context: Context
+        get() = _context
+        set(value) {
+            _context = value
+        }
+}

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/MainActivity.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : AppCompatActivity() {
         layoutManager = LinearLayoutManager(this)
         binding.recyclerView.layoutManager = layoutManager
 
-        val context = this.applicationContext
+        CSSApplication.context = this.applicationContext
 
         connectionLiveData = ConnectionLiveData(this)
         connectionLiveData.observe(this, { isNetworkAvailable ->
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity() {
 
             // TODO: Check for autostart==true
             if (isNetworkAvailable) {
-                ServerConnection.getInstance().connectIfPossible(context)
+                ServerConnection.getInstance().connectIfPossible()
             }
         })
     }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/SettingsActivity.kt
@@ -67,9 +67,6 @@ class SettingsActivity : AppCompatActivity(),
             openWeatherDialog()
         }
 
-        // Used in the connectBtn onClickListener and connectionLiveData observer
-        val context = this.applicationContext
-
         binding.connectBtn.setOnClickListener {
             if (serverLiveData.value == null) {
                 Log.e("connectOnclick", "ConnectBtn clicked with no state!")
@@ -77,7 +74,7 @@ class SettingsActivity : AppCompatActivity(),
                 serverLiveData.value == ConnectionState.NO_CREDENTIALS
             ) {
                 // Setup a connection.
-                ServerConnection.getInstance().connectIfPossible(context)
+                ServerConnection.getInstance().connectIfPossible()
             } else if (serverLiveData.value == ConnectionState.CONNECTED) {
                 // Close the connection.
                 ServerConnection.getInstance().close()
@@ -98,7 +95,7 @@ class SettingsActivity : AppCompatActivity(),
 
             // TODO: Check for autostart==true
             if (serverLiveData.value == ConnectionState.CLOSED) {
-                ServerConnection.getInstance().connectIfPossible(context)
+                ServerConnection.getInstance().connectIfPossible()
             }
 
             updateUI()

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/Footage.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/Footage.kt
@@ -1,0 +1,8 @@
+package com.camerasecuritysystem.client.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Footage(
+    val filename: String
+)

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/Footage.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/Footage.kt
@@ -2,7 +2,17 @@ package com.camerasecuritysystem.client.models
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Holds information about a video file.
+ * @property filename The name of the video file
+ * @property duration Length of the video in ms
+ * @property resolution Formatted as WIDTHxHEIGHT, both in pixels
+ * @property bitrate Bitrate of the video in bits / second
+ */
 @Serializable
 data class Footage(
-    val filename: String
+    val filename: String,
+    val duration: Int? = null,
+    val resolution: String? = null,
+    val bitrate: Int? = null
 )

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
@@ -1,19 +1,22 @@
 package com.camerasecuritysystem.client.models
 
-class FootageHandler {
+import com.camerasecuritysystem.client.CSSApplication
+import java.io.File
 
-    companion object {
-        @JvmStatic fun getAllFootage(): ArrayList<Footage> {
-            //Create array that will contain all video files
-            val allFootage = ArrayList<Footage>()
+object FootageHandler {
+    fun getAllFootage(): ArrayList<Footage> {
+        val context = CSSApplication.context
 
-            //Get all footage from sandbox
-            //Now test data:
-            allFootage.add(Footage(filename = "video.mp4"))
-            allFootage.add(Footage(filename = "video1.mp4"))
+        // Create array that will contain all video files
+        val allFootage = ArrayList<Footage>()
 
-            return allFootage
+        // Get all footage from sandbox
+        val files = File("${context.filesDir}/dashcam/").listFiles()
+
+        files?.forEach { file ->
+            allFootage.add(Footage(file.name))
         }
-    }
 
+        return allFootage
+    }
 }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
@@ -1,9 +1,20 @@
 package com.camerasecuritysystem.client.models
 
+import android.media.MediaMetadataRetriever
+import android.media.MediaMetadataRetriever.METADATA_KEY_BITRATE
+import android.media.MediaMetadataRetriever.METADATA_KEY_DURATION
+import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT
+import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH
+import android.util.Log
 import com.camerasecuritysystem.client.CSSApplication
 import java.io.File
+import java.lang.Exception
+import java.lang.NumberFormatException
+import kotlin.collections.ArrayList
 
 object FootageHandler {
+    private const val tag = "FootageHandler"
+
     fun getAllFootage(): ArrayList<Footage> {
         val context = CSSApplication.context
 
@@ -14,9 +25,52 @@ object FootageHandler {
         val files = File("${context.filesDir}/dashcam/").listFiles()
 
         files?.forEach { file ->
-            allFootage.add(Footage(file.name))
+            allFootage.add(getFootageMetadata(file))
         }
 
         return allFootage
+    }
+
+    fun getFootageMetadata(file: File): Footage {
+        var duration: Int? = null
+        var resolution: String? = null
+        var bitrate: Int? = null
+
+        val retriever = MediaMetadataRetriever()
+        retriever.setDataSource(file.path)
+
+        try {
+            // Retrieve video length
+            val durationStr = retriever.extractMetadata(METADATA_KEY_DURATION)
+            val durationInt = durationStr?.toInt()
+            if (durationInt != null && durationInt >= 0 && durationInt <= Int.MAX_VALUE) {
+                duration = durationInt
+            }
+
+            // Retrieve video resolution
+            val width = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)
+            val height = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)
+            if (width != null && height != null) {
+                resolution = "${width}x$height"
+            }
+
+            // Retrieve bitrate
+            val bitrateStr = retriever.extractMetadata(METADATA_KEY_BITRATE)
+            val bitrateInt = bitrateStr?.toInt()
+            if (bitrateInt != null && bitrateInt >= 0 && bitrateInt <= Int.MAX_VALUE) {
+                bitrate = bitrateInt
+            }
+        } catch (ex: NumberFormatException) {
+            Log.e(tag, "NumberFormat: ${ex.message}")
+        } catch (ex: Exception) {
+            Log.e(tag, "Error occurred: ${ex.message}")
+        }
+
+        return Footage(
+            filename = file.name,
+            duration = duration,
+            resolution = resolution,
+            bitrate = bitrate
+        )
     }
 }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/FootageHandler.kt
@@ -3,14 +3,14 @@ package com.camerasecuritysystem.client.models
 class FootageHandler {
 
     companion object {
-        @JvmStatic fun getAllFootage(): ArrayList<String> {
+        @JvmStatic fun getAllFootage(): ArrayList<Footage> {
             //Create array that will contain all video files
-            var allFootage = ArrayList<String>()
+            val allFootage = ArrayList<Footage>()
 
             //Get all footage from sandbox
             //Now test data:
-            allFootage.add("video.mp4")
-            allFootage.add("video1.mp4")
+            allFootage.add(Footage(filename = "video.mp4"))
+            allFootage.add(Footage(filename = "video1.mp4"))
 
             return allFootage
         }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/Message.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/Message.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Message(
-    val type: MessageType,          // Mandatory
-    val id: Int                     = 0,
-    val password: String?           = null,
-    val footage: ArrayList<String>? = null
+    val type: MessageType, // Mandatory
+    val id: Int = 0,
+    val password: String? = null,
+    val footage: ArrayList<Footage>? = null
 )

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/MessageHandler.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/MessageHandler.kt
@@ -1,22 +1,22 @@
 package com.camerasecuritysystem.client.models
 
-class MessageHandler {
+import android.util.Log
 
-    companion object {
-        @JvmStatic suspend fun handleMessage(message: Message, serverConnection: ServerConnection) {
+object MessageHandler {
+    private const val tag = "MessageHandler"
 
-            when (message.type) {
-                MessageType.FOOTAGE_REQUEST_ALL -> {
-                    serverConnection.sendMessage( Message(
+    suspend fun handleMessage(message: Message, serverConnection: ServerConnection) {
+        when (message.type) {
+            MessageType.FOOTAGE_REQUEST_ALL -> {
+                // Get all footage and send the response
+                serverConnection.sendMessage(
+                    Message(
                         type = MessageType.FOOTAGE_RESPONSE_ALL,
                         footage = FootageHandler.getAllFootage()
-                    ))
-                }
-                MessageType.DOWNLOAD_REQUEST -> {
-
-                }
+                    )
+                )
             }
+            else -> Log.d(tag, "Not handling incoming message of type ${message.type}!")
         }
     }
-
 }

--- a/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
+++ b/app/src/main/kotlin/com/camerasecuritysystem/client/models/ServerConnection.kt
@@ -2,6 +2,7 @@ package com.camerasecuritysystem.client.models
 
 import android.content.Context
 import android.util.Log
+import com.camerasecuritysystem.client.CSSApplication
 import com.camerasecuritysystem.client.KeyStoreHelper
 import com.camerasecuritysystem.client.R
 import com.camerasecuritysystem.client.cassert
@@ -188,11 +189,13 @@ class ServerConnection {
         callback(_state)
     }
 
-    private fun credentialsEntered(context: Context): Boolean {
-        var sharedPreferences =
+    private fun credentialsEntered(): Boolean {
+        val context = CSSApplication.context
+
+        val sharedPreferences =
             context.getSharedPreferences("com.camerasecuritysystem.client", Context.MODE_PRIVATE)
 
-        val camera_id =
+        val cameraid =
             sharedPreferences.getString(context.resources.getString(R.string.camera_id), null)
         val pwd = sharedPreferences.getString(context.resources.getString(R.string.encPwd), null)
         val pwdIVByte =
@@ -201,12 +204,12 @@ class ServerConnection {
         val hostname =
             sharedPreferences.getString(context.resources.getString(R.string.ip_address), null)
 
-        var credentials = arrayOf(camera_id, pwd, pwdIVByte, port, hostname)
+        val credentials = arrayOf(cameraid, pwd, pwdIVByte, port, hostname)
 
         return credentials.contains(null) == false
     }
 
-    fun connectIfPossible(context: Context) {
+    fun connectIfPossible() {
         if (isConnected()) {
             Log.e(tag, "Already connected")
             return
@@ -217,7 +220,7 @@ class ServerConnection {
             return
         }
 
-        if (!credentialsEntered(context)) {
+        if (!credentialsEntered()) {
             state = ConnectionState.NO_CREDENTIALS
             return
         }
@@ -228,15 +231,17 @@ class ServerConnection {
         }
 
         GlobalScope.launch {
-            initializeConnection(getCredentials(context))
+            initializeConnection(getCredentials())
         }
     }
 
-    private fun getCredentials(context: Context): HashMap<String, String> {
+    private fun getCredentials(): HashMap<String, String> {
+        val context = CSSApplication.context
+
         val sharedPreferences =
             context.getSharedPreferences("com.camerasecuritysystem.client", Context.MODE_PRIVATE)
 
-        val camera_id =
+        val cameraid =
             sharedPreferences.getString(context.resources.getString(R.string.camera_id), null)
         val pwd = sharedPreferences.getString(context.resources.getString(R.string.encPwd), null)
         val pwdIVByte =
@@ -247,7 +252,7 @@ class ServerConnection {
 
         val hashMap: HashMap<String, String> = HashMap()
 
-        hashMap.put(context.resources.getString(R.string.camera_id), camera_id!!)
+        hashMap.put(context.resources.getString(R.string.camera_id), cameraid!!)
         hashMap.put(context.resources.getString(R.string.encPwd), pwd!!)
         hashMap.put(context.resources.getString(R.string.pwdIVByte), pwdIVByte!!)
         hashMap.put(context.resources.getString(R.string.port), port!!)


### PR DESCRIPTION
For footage_all requests, the app returns a list of all filenames of footage files on the app, including metadata information if available.

In order to access the internal app storage in a standalone object file, the application context has been placed in a static class.